### PR TITLE
Fixes locale injection in LocalizedNumber

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/i18n/LocalizedNumber.java
+++ b/src/main/java/br/com/caelum/vraptor/i18n/LocalizedNumber.java
@@ -18,7 +18,7 @@ public class LocalizedNumber implements LocalizedInfo {
 		this.key = key;
 		this.bundle = bundle;
 		this.locale = locale;
-		this.formatter = NumberFormat.getNumberInstance(bundle.getLocale());
+		this.formatter = NumberFormat.getNumberInstance(locale);
 	}
 
 	@Override


### PR DESCRIPTION
Uses injected locale instead of bundle locale. It fixes a NPE in NumberInstance creation.
