### PR TITLE
Removed unnecessary environment condition

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/i18n/I18nLocalization.java
+++ b/src/main/java/br/com/caelum/vraptor/i18n/I18nLocalization.java
@@ -3,6 +3,7 @@ package br.com.caelum.vraptor.i18n;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.Specializes;
 import javax.inject.Inject;
@@ -10,40 +11,33 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.jstl.core.Config;
 
 import br.com.caelum.vraptor.core.JstlLocalization;
-import br.com.caelum.vraptor.environment.Environment;
 
 /**
  * ResourceBundle producer to locale configuration 
  * @author Denilson Telaroli
  */
-@Specializes
+@RequestScoped @Specializes
 public class I18nLocalization extends JstlLocalization {
 
-	private static final String DEFAULT_ENABLED = "true";
-	private static final String ENABLED = DEFAULT_ENABLED;
 	private final HttpServletRequest request;
-	private final Environment env;
 
 	/** 
 	 * @deprecated CDI eyes only
 	 */
 	protected I18nLocalization() {
-		this(null, null);
+		this(null);
 	}
 
 	@Inject
-	public I18nLocalization(HttpServletRequest request, Environment env) {
+	public I18nLocalization(HttpServletRequest request) {
 		super(request);
 		this.request = request;
-		this.env = env;
 	}
 	
 	@Override
 	@Produces
 	public ResourceBundle getBundle() {
-		if(env.get("locale.enableFromParameter", DEFAULT_ENABLED).equals(ENABLED)) {
-			setLocaleFromRequestParameter();
-		}
+		setLocaleFromRequestParameter();
 		return super.getBundle();
 	}
 	

--- a/src/test/java/br/com/caelum/vraptor/i18n/I18nLocalizationTest.java
+++ b/src/test/java/br/com/caelum/vraptor/i18n/I18nLocalizationTest.java
@@ -2,7 +2,6 @@ package br.com.caelum.vraptor.i18n;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -19,14 +18,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import br.com.caelum.vraptor.environment.Environment;
 import br.com.caelum.vraptor.http.MutableRequest;
 
 @SuppressWarnings("deprecation") 
 public class I18nLocalizationTest {
 
 	@Mock MutableRequest request;
-	@Mock Environment env;
 	@Mock ServletContext context;
 	HttpSession session;
 	I18nLocalization i18n;
@@ -69,8 +66,7 @@ public class I18nLocalizationTest {
 		defaultLocale = Locale.getDefault();
 		when(request.getSession()).thenReturn(session);
 		when(request.getServletContext()).thenReturn(context);
-		when(env.get(anyString(), anyString())).thenReturn("true");
-		i18n = new I18nLocalization(request, env);
+		i18n = new I18nLocalization(request);
 	}
 
 	private void assertDefaultLocale() {
@@ -104,17 +100,6 @@ public class I18nLocalizationTest {
 		Locale locale = getLocale();
 		assertNotNull(locale);
 		assertEquals("pt", locale.getLanguage());
-	}
-	
-	@Test
-	public void shouldDisableFeatureSetFromParameterByEnv() {
-		when(env.get("locale.enableFromParameter", "true")).thenReturn("false");
-		when(request.getParameter("_locale")).thenReturn("pt");
-		
-		assertDefaultLocale();
-		
-		i18n.getBundle();
-		assertDefaultLocale();
 	}
 	
 	private Locale getLocale() {


### PR DESCRIPTION
The feature does not changes the default behaviour of JstlLocalization
Can be removed by CDI, 
Isn't related to Environment.
Fixed missing scope annotation. 
